### PR TITLE
Fix: Dismiss new folder modal after creation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -219,7 +219,7 @@
 
             createNewFolder(userId, folderName) {
                 const foldersRef = collection(this.db, 'users', userId, 'folders');
-                addDoc(foldersRef, { name: folderName, isExpanded: false });
+                return addDoc(foldersRef, { name: folderName, isExpanded: false });
             }
 
             deleteFolder(userId, folderId) {


### PR DESCRIPTION
The modal for creating a new folder was not being dismissed after the "Create" button was clicked.

This was because the `createNewFolder` function in the `FirestoreService` was not returning the promise from the `addDoc` call. This caused the `.finally()` block in the calling function, which is responsible for hiding the modal, to execute immediately without waiting for the asynchronous operation to complete.

The fix is to add a `return` statement to the `addDoc` call, ensuring the promise is correctly propagated and the modal is hidden only after the folder has been created.